### PR TITLE
deprecate apiName, vpcEndpointIds & endpointType

### DIFF
--- a/lib/plugins/aws/lib/naming.js
+++ b/lib/plugins/aws/lib/naming.js
@@ -249,8 +249,12 @@ module.exports = {
 
   // API Gateway
   getApiGatewayName() {
-    if (this.provider.serverless.service.provider.apiName) {
-      return `${this.provider.serverless.service.provider.apiName}`;
+    const apiName =
+      _.get(this.provider.serverless.service.provider.apiGateway, 'apiName') ||
+      this.provider.serverless.service.provider.apiName;
+
+    if (apiName) {
+      return `${apiName}`;
     }
 
     return _.get(this.provider.serverless.service.provider.apiGateway, 'shouldStartNameWithService')

--- a/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.js
+++ b/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.js
@@ -14,19 +14,21 @@ module.exports = {
 
     this.apiGatewayRestApiLogicalId = this.provider.naming.getRestApiLogicalId();
 
-    let endpointType = 'EDGE';
-    let vpcEndpointIds;
+    const endpointType =
+      _.get(this.serverless.service.provider.apiGateway, 'endpointType') ||
+      this.serverless.service.provider.endpointType;
+
+    const vpcEndpointIds =
+      _.get(this.serverless.service.provider.apiGateway, 'vpcEndpointIds') ||
+      this.serverless.service.provider.vpcEndpointIds;
+
     let BinaryMediaTypes;
     if (apiGateway.binaryMediaTypes) {
       BinaryMediaTypes = apiGateway.binaryMediaTypes;
     }
 
-    if (this.serverless.service.provider.endpointType) {
-      endpointType = this.serverless.service.provider.endpointType.toUpperCase();
-
-      if (this.serverless.service.provider.vpcEndpointIds) {
-        vpcEndpointIds = this.serverless.service.provider.vpcEndpointIds;
-
+    if (endpointType && endpointType.length) {
+      if (vpcEndpointIds && vpcEndpointIds.length) {
         if (endpointType !== 'PRIVATE') {
           throw new ServerlessError('VPC endpoint IDs are only available for private APIs');
         }
@@ -37,7 +39,7 @@ module.exports = {
       Types: [endpointType],
     };
 
-    if (vpcEndpointIds) {
+    if (vpcEndpointIds && vpcEndpointIds.length) {
       EndpointConfiguration.VpcEndpointIds = vpcEndpointIds;
     }
 

--- a/lib/plugins/aws/provider.js
+++ b/lib/plugins/aws/provider.js
@@ -583,11 +583,15 @@ class AwsProvider {
                 apiKeySourceType: {
                   anyOf: ['HEADER', 'AUTHORIZER'].map(caseInsensitive),
                 },
+                apiName: { type: 'string' },
                 binaryMediaTypes: {
                   type: 'array',
                   items: { type: 'string', pattern: '^\\S+\\/\\S+$' },
                 },
                 description: { type: 'string' },
+                endpointType: {
+                  anyOf: ['REGIONAL', 'EDGE', 'PRIVATE'].map(caseInsensitive),
+                },
                 metrics: { type: 'boolean' },
                 minimumCompressionSize: { type: 'integer', minimum: 0, maximum: 10485760 },
                 resourcePolicy: { $ref: '#/definitions/awsResourcePolicyStatements' },
@@ -644,6 +648,10 @@ class AwsProvider {
                   ],
                 },
                 websocketApiId: { $ref: '#/definitions/awsCfInstruction' },
+                vpcEndpointIds: {
+                  type: 'array',
+                  items: { $ref: '#/definitions/awsCfInstruction' },
+                },
               },
               additionalProperties: false,
             },

--- a/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.test.js
+++ b/test/unit/lib/plugins/aws/package/compile/events/apiGateway/lib/restApi.test.js
@@ -153,8 +153,10 @@ describe('#compileRestApi()', () => {
   });
 
   it('should throw error if endpointType property is not PRIVATE and vpcEndpointIds property is [id1]', () => {
-    awsCompileApigEvents.serverless.service.provider.endpointType = 'Testing';
-    awsCompileApigEvents.serverless.service.provider.vpcEndpointIds = ['id1'];
+    awsCompileApigEvents.serverless.service.provider.endpointTypeapiKeys = {
+      endpointType: ['Testing'],
+    };
+    awsCompileApigEvents.serverless.service.provider.apiGateway = { vpcEndpointIds: ['id1'] };
     expect(() => awsCompileApigEvents.compileRestApi()).to.throw(Error);
   });
 });


### PR DESCRIPTION
Problems: 
Not able to deprecate endpointType